### PR TITLE
Bug when starting without config file. Before, one would be created.

### DIFF
--- a/taggo
+++ b/taggo
@@ -15,17 +15,18 @@ class Taggo:
     def __init__(self):
         self.mydir = os.path.dirname(os.path.abspath(__file__))
 
-        # Look for config
+        # Look for config file in the taggo directory. If it's not
+        # found, then we'll assume we want to use $HOME/.taggo.cfg
         self.config_file = None
         if os.path.isfile('%s/taggo.cfg' % self.mydir):
             self.config_file = '%s/taggo.cfg' % self.mydir
         else:
-            homepath = os.environ.get('HOME', None)
-            home_cfg = '%s/.taggo.cfg' % homepath
-            if os.path.isfile(home_cfg):
-                self.config_file = home_cfg
+            home_path = os.environ.get('HOME', None)
+            home_cfg = '%s/.taggo.cfg' % home_path
+            self.config_file = home_cfg
 
-        if not self.config_file:
+        # If we can't read the config file, create it
+        if not os.path.isfile(self.config_file):
             print 'Writing default config to %s\n' % self.config_file
             self.write_config()
 


### PR DESCRIPTION
Hi @Xeor,
sorry for flooding you with pull requests. This commit fixes a bug when
starting with no config file, either in $HOME/.taggo.cfg or in the taggo
folder.

I changed the behaviour a bit so that we assume that, if we don't have a
config file in the taggo directory, we create one in $HOME/.taggo.cfg
and use it instead.
