### PR TITLE
Include metadata in installed packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     author="Lars Solberg",
     author_email='lars.solberg@gmail.com',
     url='https://github.com/xeor/taggo',
-    packages=find_packages(include=['taggo'], exclude=['tests']),
+    packages=find_packages(include=['taggo', 'taggo.metadata'], exclude=['tests']),
     include_package_data=True,
     install_requires=requirements,
     extras_require=extras,


### PR DESCRIPTION
I'm trying to create an AUR package, hence need to manually run `python setup.py install`.
However, once installed, I noticed that the `metadata` folder won't be included and taggo won't run, hence this proposed change.